### PR TITLE
Fix regression for missing libgdiplus

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -113,14 +113,21 @@ namespace NzbDrone.Common.Disk
         {
             try
             {
+                GdiPlusInterop.CheckGdiPlus();
+                
                 using (var bmp = new Bitmap(filename))
                 {
                 }
                 return true;
             }
+            catch (DllNotFoundException ex)
+            {
+                _logger.Debug(ex, "Could not find libgdiplus. Cannot test if image is corrupt.");
+                return true;
+            }
             catch (Exception ex)
             {
-                //_logger.Debug(ex, "Corrupted image found at: {0}. Redownloading...", filename);
+                _logger.Debug(ex, "Corrupted image found at: {0}.", filename);
                 return false;
             }
         }


### PR DESCRIPTION
Add back error handling for systems where libgdiplus is not available. Should fix #1065

#### Database Migration
No

#### Description
This function was moved but missed the exception handling for when the libgdiplus library doesn't exist on the system. Adding it back.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* #1065
